### PR TITLE
Remove o listener do ExoPlayer no dispose

### DIFF
--- a/just_audio/android/src/main/java/com/ryanheise/just_audio/AudioPlayer.java
+++ b/just_audio/android/src/main/java/com/ryanheise/just_audio/AudioPlayer.java
@@ -1021,6 +1021,7 @@ public class AudioPlayer implements MethodCallHandler, Player.Listener, Metadata
         mediaSource = null;
         clearAudioEffects();
         if (player != null) {
+            player.removeListener(this);
             player.release();
             player = null;
             processingState = ProcessingState.none;


### PR DESCRIPTION
Antes de dar release, o AudioPlayer do just_audio não estava se removendo de listener do ExoPlayer. Esse PR adiciona essa linha antes do `release()`

Close https://github.com/StudioSol/PalcoMP3Geral/issues/1781