### PR TITLE
Testando count > index

### DIFF
--- a/just_audio/darwin/Classes/AudioPlayer.m
+++ b/just_audio/darwin/Classes/AudioPlayer.m
@@ -364,7 +364,7 @@
 - (int)getDuration {
     if (_processingState == none || _processingState == loading) {
         return -1;
-    } else if (_indexedAudioSources && _indexedAudioSources.count > 0) {
+    } else if (_indexedAudioSources && _indexedAudioSources.count > _index) {
         int v = (int)(1000 * CMTimeGetSeconds(_indexedAudioSources[_index].duration));
         return v;
     } else {


### PR DESCRIPTION
No [PR](https://github.com/CifraClub/just_audio/pull/2) passado, o @talesbarreto já tinha feito um fix para o mesmo crash mas em lugares diferentes. Faltou só colocar aqui aparentemente.

[Crash no firebase](https://console.firebase.google.com/u/0/project/studiosol.com.br:api-project-784894268384/crashlytics/app/ios:br.com.studiosol.AplicativoPalcoIPhone/issues/0c144d741504085e30e237e1bfab753c?time=last-seven-days&types=crash&versions=4.0.22%20(510))